### PR TITLE
Fix gRPC Errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pulumi==3.59.1
-pulumi-aws==5.33.0
+pulumi>=3.59.1,<4.0.0
+pulumi-aws>=5.33.0,<6.0.0
 pulumi-awsx>=1.0.2,<2.0.0


### PR DESCRIPTION
When left a few weeks and pulumi command is run i.e `pulumi preview` the stack errors with a protobuf, gRPC error.

Upgrading packages in requirements fixes this. (Software Rott)