### PR TITLE
Fix gRPC Errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pulumi==3.59.1
-pulumi-aws==5.33.0
+pulumi>=3.59.1,<4.0.0
+pulumi-aws>=5.33.0,<6.0.0
 pulumi-awsx>=1.0.2,<2.0.0

--- a/src/main.py
+++ b/src/main.py
@@ -104,6 +104,7 @@ if __name__ == '__main__':
 
         while not os.path.exists(file_path):
             time.sleep(5)
+            print(file_path)
             if os.path.isfile(file_path): break
 
         with open(file_path, 'rb') as file:

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,3 @@
-yt-dlp==2023.3.4
-streamlit==1.20.0
-watchdog==3.0.0
+yt-dlp>=2023.07.06
+streamlit==1.23.1
+watchdog>=3.0.0,<4.0.0


### PR DESCRIPTION
When left a few weeks and pulumi command is run i.e `pulumi preview` the stack errors with a protobuf, gRPC error.

Upgrading packages in requirements fixes this. (Software Rott)