### PR TITLE
Chore: Dependency upgrades

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,3 @@
-yt-dlp>=2023.07.06
-streamlit==1.23.1
+yt-dlp>=2025.7.21
+streamlit==1.37.0
 watchdog>=3.0.0,<4.0.0


### PR DESCRIPTION
Upgrade libs from:
- yt-dlp 2023.07.06 to 2025.7.21
- streamlit 1.23.1 to 1.37.0